### PR TITLE
Ensure EUDR declaration alerts show only failing lines

### DIFF
--- a/planetio/models/eudr_models.py
+++ b/planetio/models/eudr_models.py
@@ -95,6 +95,7 @@ class EUDRDeclaration(models.Model):
         "eudr.declaration.line.alert",
         "declaration_id",
         string="Deforestation Alerts",
+        domain=[("line_id.external_ok", "=", False)],
         readonly=True,
     )
 


### PR DESCRIPTION
## Summary
- add a domain to the eudr.declaration.alert_ids relation so that it only returns alerts from lines not marked as externally OK

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e1adb1daa8833395a026a1b229add8

## Summary by Sourcery

Bug Fixes:
- Add domain filter to eudr.declaration.alert_ids relation to exclude lines where external_ok is true