### PR TITLE
Remove nyan cat progress bar style option

### DIFF
--- a/web_progress/static/src/js/progress_bar.js
+++ b/web_progress/static/src/js/progress_bar.js
@@ -24,6 +24,7 @@ var framework_unblockUI = framework.unblockUI;
 var ProgressBar = Widget.extend({
     template: "WebProgressBar",
     progress_timer: false,
+    allowedStyles: ['standard', 'simple'],
     events: {
         "click .progress_style": "setStyleClick",
     },
@@ -36,9 +37,11 @@ var ProgressBar = Widget.extend({
         this.cancel_html = QWeb.render('WebProgressBarCancel', {});
         this.cancel_confirm_html = QWeb.render('WebProgressBarCancelConfirm', {})
         this.style = localStorage.getItem(this.style_localstorage_key);
-        if (!session.is_system || !this.style) {
+        this.style = this._normalizeStyle(this.style);
+        if (!session.is_system) {
             this.style = 'standard';
         }
+        localStorage.setItem(this.style_localstorage_key, this.style);
     },
     start: function() {
         this.$progress_outline = this.$();
@@ -76,6 +79,7 @@ var ProgressBar = Widget.extend({
             // styles changeable only for admins
             return;
         }
+        name = this._normalizeStyle(name);
         if (this.style && this.style !== name) {
             this.removeStyle(this.style);
             if (this.last_progress_list) {
@@ -86,6 +90,12 @@ var ProgressBar = Widget.extend({
         _.invoke(this.all_elements, 'addClass', name);
         this.style = name;
         localStorage.setItem(this.style_localstorage_key, name);
+    },
+    _normalizeStyle: function(name) {
+        if (name && _.contains(this.allowedStyles, name)) {
+            return name;
+        }
+        return 'standard';
     },
     removeStyle: function(name) {
         _.invoke(this.all_elements, 'removeClass', name);

--- a/web_progress/static/src/xml/progress_bar.xml
+++ b/web_progress/static/src/xml/progress_bar.xml
@@ -18,7 +18,6 @@
                 <div class="progress_style">
                     <a href="#" id="standard" onclick="return false;">standard</a>
                     <a href="#" id="simple" onclick="return false;">simple</a>
-                    <a href="#" id="nyan" onclick="return false;">nyan cat</a>
                 </div>
             </div>
             <div id="progress_user" class="o_progress_user" style="visibility:hidden"/>


### PR DESCRIPTION
## Summary
- remove the nyan cat entry from the progress bar style selector
- normalize stored and incoming styles to supported options so legacy values fall back to standard

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e1b0d179c4833382b4f7ec36b775df

## Summary by Sourcery

Remove unsupported nyan cat progress bar style option and enforce style normalization with fallback to 'standard'.

Enhancements:
- Restrict allowed progress bar styles to 'standard' and 'simple' by removing the nyan cat option from the selector.
- Implement _normalizeStyle method to coerce stored and incoming style values to supported options, defaulting invalid entries to 'standard'.
- Persist normalized style values to localStorage upon initialization and style changes.