### PR TITLE
Add export action for externally validated EUDR lines

### DIFF
--- a/planetio/views/eudr_views.xml
+++ b/planetio/views/eudr_views.xml
@@ -43,6 +43,7 @@
           <button name="action_analyze_deforestation" type="object" class="oe_highlight btn-success" string="Deforestation analysis" icon="fa-tree"/>
           <button name="action_create_deforestation_geojson" type="object" class="btn-secondary" string="Deforestation GeoJSON" icon="fa-download" invisible="1"/>
           <button name="action_create_geojson" type="object" class="btn-secondary" string="Traces GeoJSON" icon="fa-save" invisible="1"/>
+          <button name="action_download_external_ok_json" type="object" class="btn-secondary" string="Download OK JSON" icon="fa-download"/>
           <button name="action_transmit_dds" type="object" class="oe_highlight" string="Trasmit DDS" icon="fa-paper-plane"/>
           <field name="stage_id" widget="statusbar" options="{'clickable': '1'}"/>
         </header>


### PR DESCRIPTION
## Summary
- add a server action on eudr.declaration to export JSON for lines marked as external_ok
- expose a Download OK JSON button on the declaration form header to trigger the new export

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e1b1cdc7708333ae67ee31611e7446

## Summary by Sourcery

Provide a new export action for EUDR declaration lines flagged as externally validated, allowing users to download their data as JSON.

New Features:
- Add action_download_external_ok_json server method to generate JSON for lines with external_ok flag
- Add Download OK JSON button in the declaration form header to trigger the new export