### PR TITLE
Allow configuring DDS retrieval root element

### DIFF
--- a/planetio/services/eudr_adapter_odoo.py
+++ b/planetio/services/eudr_adapter_odoo.py
@@ -497,7 +497,16 @@ def action_retrieve_dds_numbers(record):
     if not dds_uuid:
         raise UserError(_('Nessun DDS Identifier (UUID) presente sul record.'))
 
-    client = EUDRRetrievalClient(endpoint, username, apikey, wsse_mode, webservice_client_id=wsclient)
+    root_tag = ICP.get_param('planetio.eudr_retrieval_root_tag')
+
+    client = EUDRRetrievalClient(
+        endpoint,
+        username,
+        apikey,
+        wsse_mode,
+        webservice_client_id=wsclient,
+        retrieval_root_tag=root_tag,
+    )
 
     # build + attach request for audit
     retrieval_xml = client.build_retrieval_xml(dds_uuid)

--- a/planetio_dds_api/controllers/dds_api.py
+++ b/planetio_dds_api/controllers/dds_api.py
@@ -258,11 +258,19 @@ class DDSApiController(http.Controller):
         apikey = ICP.get_param('planetio.eudr_apikey') or ''
         wsse_mode = (ICP.get_param('planetio.eudr_wsse_mode') or 'digest').lower()
         wsclient = ICP.get_param('planetio.eudr_webservice_client_id') or 'eudr-test'
+        root_tag = ICP.get_param('planetio.eudr_retrieval_root_tag')
 
         if not username or not apikey:
             raise UserError(_('EUDR credentials are missing. Configure planetio.eudr_user and planetio.eudr_apikey.'))
 
-        return EUDRRetrievalClient(endpoint, username, apikey, wsse_mode, webservice_client_id=wsclient)
+        return EUDRRetrievalClient(
+            endpoint,
+            username,
+            apikey,
+            wsse_mode,
+            webservice_client_id=wsclient,
+            retrieval_root_tag=root_tag,
+        )
 
     def _format_retrieval_error(self, client, result):
         http_status = result.get('httpStatus') or 500

--- a/tests/test_eudr_retrieval_client.py
+++ b/tests/test_eudr_retrieval_client.py
@@ -1,0 +1,54 @@
+import importlib
+import importlib
+import sys
+import types
+from pathlib import Path
+
+
+repo_root = Path(__file__).resolve().parents[1]
+sys.path.append(str(repo_root))
+
+planetio_pkg = sys.modules.setdefault("planetio", types.ModuleType("planetio"))
+planetio_pkg.__path__ = [str((repo_root / "planetio").resolve())]
+
+services_pkg = types.ModuleType("planetio.services")
+services_pkg.__path__ = [str((repo_root / "planetio" / "services").resolve())]
+planetio_pkg.services = services_pkg
+sys.modules["planetio.services"] = services_pkg
+
+module = importlib.import_module("planetio.services.eudr_client_retrieve")
+EUDRRetrievalClient = module.EUDRRetrievalClient
+
+
+def test_sanitize_root_tag_defaults():
+    assert EUDRRetrievalClient._sanitize_root_tag(None) == "retrieveDdsNumberRequest"
+    assert EUDRRetrievalClient._sanitize_root_tag("") == "retrieveDdsNumberRequest"
+
+
+def test_sanitize_root_tag_removes_namespace_and_spaces():
+    assert (
+        EUDRRetrievalClient._sanitize_root_tag(" retr:RetrieveDdsNumberRequest  ")
+        == "RetrieveDdsNumberRequest"
+    )
+
+
+def test_custom_root_tag_is_used_when_building_xml():
+    client = EUDRRetrievalClient(
+        "https://example.com",
+        "user",
+        "apikey",
+        retrieval_root_tag="RetrieveDdsNumberRequest",
+    )
+    xml = client.build_retrieval_xml("1234")
+    assert "<retr:RetrieveDdsNumberRequest" in xml
+
+
+def test_invalid_custom_root_tag_falls_back_to_default():
+    client = EUDRRetrievalClient(
+        "https://example.com",
+        "user",
+        "apikey",
+        retrieval_root_tag="123 invalid",
+    )
+    xml = client.build_retrieval_xml("abcd")
+    assert "<retr:retrieveDdsNumberRequest" in xml


### PR DESCRIPTION
## Summary
- allow overriding the DDS retrieval SOAP root element so different environments can be satisfied
- wire the optional configuration parameter through the Odoo action helper and JSON API controller
- add unit tests covering tag sanitisation and XML generation

## Testing
- pytest tests/test_eudr_retrieval_client.py

------
https://chatgpt.com/codex/tasks/task_e_68e1c3afb04c8333919ef0e56a3e3b3a

## Summary by Sourcery

Enable specifying and sanitizing the DDS retrieval SOAP root element in requests and propagate the configuration through Odoo and API controllers.

New Features:
- Allow overriding the DDS retrieval SOAP root element via an optional client constructor parameter.

Enhancements:
- Sanitize and validate custom root tag with fallback to the default value.
- Apply the configured root tag when building retrieval XML.
- Retrieve and pass the retrieval_root_tag configuration through the Odoo action helper and JSON API controller.

Tests:
- Add unit tests for root tag sanitization and XML generation including default and invalid tag fallbacks.