### PR TITLE
feat(eudr): support multi-commodity and trader reference modes

### DIFF
--- a/planetio/models/excel_import_service.py
+++ b/planetio/models/excel_import_service.py
@@ -107,6 +107,9 @@ class ExcelImportService(models.AbstractModel):
 
         base_name = (getattr(getattr(job, "attachment_id", None), "name", None) or "EUDR Import").rsplit(".", 1)[0]
 
+        if decl.dds_mode == "single_multi" and hasattr(job, "_create_multi_records_from_rows"):
+            return job._create_multi_records_from_rows(decl, rows)
+
         count = 0
         for idx, r in enumerate(rows, start=1):
             if not any(v for v in r.values() if v not in (None, "", [], {})):

--- a/planetio/security/ir.model.access.csv
+++ b/planetio/security/ir.model.access.csv
@@ -7,4 +7,8 @@ access_planetio_excel_import_wizard_user,access_planetio_excel_import_wizard_use
 access_deforestation_geometry_wizard_user,access_deforestation_geometry_wizard_user,model_deforestation_geometry_wizard,,1,1,1,1
 access_excel_import_template_user,access_excel_import_template_user,model_excel_import_template,,1,1,1,1
 access_excel_import_template_field_user,access_excel_import_template_field_user,model_excel_import_template_field,,1,1,1,1
+access_eudr_commodity_line,eudr_commodity_line,model_eudr_commodity_line,base.group_user,1,1,1,1
+access_eudr_producer,eudr_producer,model_eudr_producer,base.group_user,1,1,1,1
+access_eudr_plot,eudr_plot,model_eudr_plot,base.group_user,1,1,1,1
+access_eudr_associated_statement,eudr_associated_statement,model_eudr_associated_statement,base.group_user,1,1,1,1
 

--- a/planetio/services/eudr_adapter_odoo.py
+++ b/planetio/services/eudr_adapter_odoo.py
@@ -8,6 +8,7 @@ from odoo.exceptions import UserError
 from .eudr_client import EUDRClient, build_geojson_b64
 from .eudr_client_retrieve import EUDRRetrievalClient
 from decimal import Decimal, InvalidOperation, ROUND_HALF_UP
+from types import SimpleNamespace
 
 
 class _SafeFormatDict(dict):
@@ -131,6 +132,184 @@ def _safe_float(value):
         return float(value)
     except (TypeError, ValueError):
         return None
+
+
+def _format_weight_value(raw):
+    try:
+        kg = Decimal(str(raw))
+    except (InvalidOperation, TypeError):
+        raise UserError(_("net_weight must be a valid number (kg)"))
+    if kg <= 0:
+        raise UserError(_("net_weight must be > 0 kg"))
+    kg_int = max(1, int(kg.to_integral_value(rounding=ROUND_HALF_UP)))
+    return str(kg_int)
+
+
+def _species_info_xml(record):
+    coffee = getattr(record, "coffee_species", False)
+    scientific = (coffee and getattr(coffee, "scientific_name", None)) or getattr(record, "scientific_name", None)
+    common = getattr(record, "common_name", None) or (coffee and getattr(coffee, "name", None))
+    if scientific or common:
+        xml = ['<model:speciesInfo>']
+        if scientific:
+            xml.append(f'<model:scientificName>{scientific}</model:scientificName>')
+        if common:
+            xml.append(f'<model:commonName>{common}</model:commonName>')
+        xml.append('</model:speciesInfo>')
+        return ''.join(xml)
+    return ''
+
+
+def _build_producer_feature_collection(record, producer, ha_per_point):
+    features = []
+    ha_per_point = ha_per_point or 4.0
+    for idx, plot in enumerate(producer.plot_ids, start=1):
+        geom = _safe_json_loads(getattr(plot, "geometry", None))
+        if not isinstance(geom, dict) or not geom.get("type"):
+            continue
+
+        producer_name = producer.name or (_("Producer %s") % idx)
+        producer_country = (plot.country_of_production or producer.country or getattr(record.partner_id.country_id, 'code', '') or getattr(record.supplier_id.country_id, 'code', '') or 'XX').upper()
+        line_stub = SimpleNamespace(
+            farm_name=None,
+            municipality=None,
+            region=None,
+            country=plot.country_of_production or producer.country,
+            farmer_id_code=plot.plot_id,
+            name=plot.plot_id,
+        )
+        production_place = _place_description(line_stub, record, idx)
+
+        props = {
+            "ProducerName": producer_name,
+            "ProducerCountry": producer_country,
+            "PlotId": plot.plot_id or f"plot-{idx}",
+        }
+        if production_place:
+            props["ProductionPlace"] = production_place
+
+        geom_type = geom.get("type", "")
+        if geom_type == "Point":
+            area_val = plot.area_ha if plot.area_ha not in (None, "") else ha_per_point
+            try:
+                props["Area"] = float(area_val)
+            except (TypeError, ValueError):
+                props["Area"] = float(ha_per_point)
+
+        features.append({"type": "Feature", "properties": props, "geometry": geom})
+
+    if not features:
+        raise UserError(_("Producer %s has no valid plot geometries.") % (producer.name or producer.id))
+
+    return {"type": "FeatureCollection", "features": features}
+
+
+def _build_multi_commodities_xml(record, species_block, ha_per_point):
+    default_desc = record.product_description or getattr(record.product_id, "display_name", None) or record.name or ""
+    default_weight = record.net_mass_kg
+    default_hs = record.hs_code or "090111"
+    blocks = []
+
+    for position, commodity in enumerate(record.commodity_ids, start=1):
+        if not commodity.producer_ids:
+            raise UserError(_("Commodity %s has no producers.") % position)
+
+        description = commodity.description_of_goods or default_desc
+        weight_raw = commodity.net_weight_kg or default_weight
+        net_weight = _format_weight_value(weight_raw)
+        hs_heading = commodity.hs_heading or default_hs
+
+        block = [
+            '<model:commodities>',
+            f'<model:position>{position}</model:position>',
+            '<model:descriptors>',
+            f'<model:descriptionOfGoods>{description}</model:descriptionOfGoods>',
+            '<model:goodsMeasure>',
+            f'<model:netWeight>{net_weight}</model:netWeight>',
+            '</model:goodsMeasure>',
+            '</model:descriptors>',
+            f'<model:hsHeading>{hs_heading}</model:hsHeading>',
+        ]
+        if species_block:
+            block.append(species_block)
+
+        for idx, producer in enumerate(commodity.producer_ids, start=1):
+            if not producer.plot_ids:
+                raise UserError(
+                    _("Producer %(producer)s in commodity %(commodity)s has no plots.") % {
+                        "producer": producer.name or idx,
+                        "commodity": position,
+                    }
+                )
+            collection = _build_producer_feature_collection(record, producer, ha_per_point)
+            geojson_b64 = build_geojson_b64(collection)
+            producer_country = (producer.country or getattr(record.partner_id.country_id, 'code', '') or getattr(record.supplier_id.country_id, 'code', '') or 'XX').upper()
+            block.extend([
+                '<model:producers>',
+                f'<model:position>{idx}</model:position>',
+                f'<model:country>{producer_country}</model:country>',
+                f'<model:name>{producer.name or (_("Producer %s") % idx)}</model:name>',
+                f'<model:geometryGeojson>{geojson_b64}</model:geometryGeojson>',
+                '</model:producers>',
+            ])
+
+        block.append('</model:commodities>')
+        blocks.append(''.join(block))
+
+    return ''.join(blocks)
+
+
+def _build_associated_statements_xml(statements):
+    if not statements:
+        return ''
+    parts = ['<model:associatedStatements>']
+    for idx, stmt in enumerate(statements, start=1):
+        parts.append('<model:statements>')
+        parts.append(f'<model:position>{idx}</model:position>')
+        ref = (stmt.upstream_reference_number or "").strip()
+        if ref:
+            parts.append(f'<model:referenceNumber>{ref}</model:referenceNumber>')
+        dds = (stmt.upstream_dds_identifier or "").strip()
+        if dds:
+            parts.append(f'<model:ddsIdentifier>{dds}</model:ddsIdentifier>')
+        parts.append('</model:statements>')
+    parts.append('</model:associatedStatements>')
+    return ''.join(parts)
+
+
+def _build_statement_xml_common(base_vals, comment_text, associated_xml='', commodities_xml=''):
+    xml = [
+        '<eudr:SubmitStatementRequest '
+        'xmlns:eudr="http://ec.europa.eu/tracesnt/certificate/eudr/submission/v1" '
+        'xmlns:model="http://ec.europa.eu/tracesnt/certificate/eudr/model/v1" '
+        'xmlns:base="http://ec.europa.eu/sanco/tracesnt/base/v4">',
+        f'<eudr:operatorType>{base_vals["operator_type"]}</eudr:operatorType>',
+        '<eudr:statement>',
+        f'<model:internalReferenceNumber>{base_vals["internal_ref"]}</model:internalReferenceNumber>',
+        f'<model:activityType>{base_vals["activity_type"]}</model:activityType>',
+        '<model:operator>',
+        '<model:referenceNumber>',
+        '<model:identifierType>eori</model:identifierType>',
+        f'<model:identifierValue>{base_vals["eori_value"]}</model:identifierValue>',
+        '</model:referenceNumber>',
+        '<model:nameAndAddress>',
+        f'<base:name>{base_vals["company_name"]}</base:name>',
+        f'<base:country>{base_vals["company_country"]}</base:country>',
+        f'<base:address>{base_vals["company_address"]}</base:address>',
+        '</model:nameAndAddress>',
+        '</model:operator>',
+        f'<model:countryOfActivity>{base_vals["country_of_activity"]}</model:countryOfActivity>',
+        f'<model:borderCrossCountry>{base_vals["border_cross_country"]}</model:borderCrossCountry>',
+        f'<model:comment>{comment_text}</model:comment>',
+    ]
+    if associated_xml:
+        xml.append(associated_xml)
+    if commodities_xml:
+        xml.append(commodities_xml)
+    xml.append('<model:geoLocationConfidential>false</model:geoLocationConfidential>')
+    xml.append('</eudr:statement>')
+    xml.append('</eudr:SubmitStatementRequest>')
+    return ''.join(xml)
 
 
 def _get_line_geometry(line):
@@ -322,63 +501,114 @@ def submit_dds_for_batch(record):
     if not eori_value or len(eori_value) < 6:
         raise UserError(_("EORI mancante/non valido. Imposta planetio.eudr_eori nelle configurazioni."))
 
-    geojson_dict = build_dds_geojson(record)
-    attach_dds_geojson(record, geojson_dict)
-    geojson_b64 = build_geojson_b64(geojson_dict)
-
-    raw = record.net_mass_kg
-    try:
-        kg = Decimal(str(raw))
-    except (InvalidOperation, TypeError):
-        raise UserError(_("net_weight must be a valid number (kg)"))
-
-    if kg <= 0:
-        raise UserError(_("net_weight must be > 0 kg"))
-
-    # arrotondamento "commerciale", minimo 1
-    kg_int = max(1, int(kg.to_integral_value(rounding=ROUND_HALF_UP)))
-    weight = str(kg_int)
-
     client = EUDRClient(endpoint, username, apikey, wsse_mode, webservice_client_id=wsclient)
-    company_address = (record.partner_id._display_address(without_company=True) or '').replace('\n', ' ')
-
     comment_text = ((getattr(record, 'x_eudr_comment', None) or getattr(record, 'note', None) or '').strip())
-
     if not comment_text:
         comment_text = _('Submission for %s on %s by %s for lot %s') % (
-        (record.name or f'Batch-{record.id}'), fields.Date.today(),company.name,record.lot_name or 'N/A'
+            (record.name or f'Batch-{record.id}'),
+            fields.Date.today(),
+            company.name,
+            record.lot_name or 'N/A',
         )
 
-    # Take the first line with geometry to determine producer country
-    line = next((l for l in record.line_ids if l.geometry), None)
-    if line and line.country:
-        producer_country = (line.country[:2] or 'PE').upper()
-    elif record.supplier_id.country_id.code:
-        producer_country = (record.supplier_id.country_id.code or 'PE').upper()
-    else:
-        raise UserError(_('Nazione produttore mancante: imposta la nazione sul fornitore o sulle linee.'))
+    address_source = company if hasattr(company, '_display_address') else record.partner_id
+    company_address = (address_source and address_source._display_address(without_company=True)) or ''
+    company_address = (company_address or '').replace('\n', ' ') or 'Unknown Address'
 
-    submit_xml = client.build_statement_xml(
-        internal_ref=record.name or f'Batch-{record.id}',
-        operator_type=record.eudr_type_override or 'TRADER',
-        activity_type=record.activity_type.upper(),
-        company_name=company or 'Company',
-        company_address=company_address or 'Unknown Address',
-        company_country=company_country or 'IT',
-        eori_value=company.vat,
-        hs_heading=record.hs_code or '090111',
-        description_of_goods=(
-            record.coffee_species.name if record.coffee_species else (record.product_id.display_name or '')),
-        scientific_name=getattr(record.coffee_species, 'scientific_name', None),
-        common_name=getattr(record.coffee_species, 'name', None),
-        net_weight_kg=weight,
-        producer_country=(record.supplier_id.country_id.code or 'BR').upper(),
-        producer_name=record.supplier_id.name or 'Unknown Producer',
-        country_of_activity=company_country,
-        border_cross_country=company_country,
-        geojson_b64=geojson_b64,
-        comment=comment_text
-    )
+    dds_mode = getattr(record, 'dds_mode', 'single_one') or 'single_one'
+
+    base_vals = {
+        "internal_ref": record.name or f'Batch-{record.id}',
+        "operator_type": (record.eudr_type_override or 'TRADER'),
+        "activity_type": (record.activity_type or 'import').upper(),
+        "company_name": company.name or 'Company',
+        "company_country": company_country or 'IT',
+        "company_address": company_address,
+        "eori_value": eori_value,
+        "country_of_activity": company_country,
+        "border_cross_country": company_country,
+    }
+
+    submit_xml = None
+
+    if dds_mode == 'single_one':
+        geojson_dict = build_dds_geojson(record)
+        attach_dds_geojson(record, geojson_dict)
+        geojson_b64 = build_geojson_b64(geojson_dict)
+        weight = _format_weight_value(record.net_mass_kg)
+
+        line = next((l for l in record.line_ids if l.geometry), None)
+        if line and line.country:
+            producer_country = (line.country[:2] or 'PE').upper()
+        elif record.supplier_id.country_id.code:
+            producer_country = (record.supplier_id.country_id.code or 'PE').upper()
+        else:
+            raise UserError(_('Nazione produttore mancante: imposta la nazione sul fornitore o sulle linee.'))
+
+        submit_xml = client.build_statement_xml(
+            internal_ref=base_vals['internal_ref'],
+            operator_type=base_vals['operator_type'],
+            activity_type=base_vals['activity_type'],
+            company_name=base_vals['company_name'],
+            company_address=base_vals['company_address'],
+            company_country=base_vals['company_country'],
+            eori_value=eori_value,
+            hs_heading=record.hs_code or '090111',
+            description_of_goods=(
+                record.coffee_species.name if record.coffee_species else (record.product_id.display_name or '')
+            ),
+            scientific_name=getattr(record.coffee_species, 'scientific_name', None),
+            common_name=getattr(record.coffee_species, 'name', None) or getattr(record, 'common_name', None),
+            net_weight_kg=weight,
+            producer_country=producer_country,
+            producer_name=record.supplier_id.name or 'Unknown Producer',
+            country_of_activity=base_vals['country_of_activity'],
+            border_cross_country=base_vals['border_cross_country'],
+            geojson_b64=geojson_b64,
+            comment=comment_text,
+        )
+    elif dds_mode == 'single_multi':
+        if not record.commodity_ids:
+            raise UserError(_('Add at least one commodity before submitting in Multiple commodities mode.'))
+        ha_per_point = float(record.env['ir.config_parameter'].sudo().get_param('planetio.eudr_point_area_ha', '4'))
+        species_block = _species_info_xml(record)
+        commodities_xml = _build_multi_commodities_xml(record, species_block, ha_per_point)
+        if not commodities_xml:
+            raise UserError(_('Unable to build commodities payload for DDS submission.'))
+        submit_xml = _build_statement_xml_common(base_vals, comment_text, commodities_xml=commodities_xml)
+    elif dds_mode == 'trader_refs':
+        if not record.associated_statement_ids:
+            raise UserError(_('Add at least one associated statement before submitting.'))
+        associated_xml = _build_associated_statements_xml(record.associated_statement_ids)
+        submit_xml = _build_statement_xml_common(base_vals, comment_text, associated_xml=associated_xml)
+    else:
+        # Fallback to legacy behaviour
+        geojson_dict = build_dds_geojson(record)
+        attach_dds_geojson(record, geojson_dict)
+        geojson_b64 = build_geojson_b64(geojson_dict)
+        weight = _format_weight_value(record.net_mass_kg)
+        submit_xml = client.build_statement_xml(
+            internal_ref=base_vals['internal_ref'],
+            operator_type=base_vals['operator_type'],
+            activity_type=base_vals['activity_type'],
+            company_name=base_vals['company_name'],
+            company_address=base_vals['company_address'],
+            company_country=base_vals['company_country'],
+            eori_value=eori_value,
+            hs_heading=record.hs_code or '090111',
+            description_of_goods=(
+                record.coffee_species.name if record.coffee_species else (record.product_id.display_name or '')
+            ),
+            scientific_name=getattr(record.coffee_species, 'scientific_name', None),
+            common_name=getattr(record.coffee_species, 'name', None) or getattr(record, 'common_name', None),
+            net_weight_kg=weight,
+            producer_country=(record.supplier_id.country_id.code or 'BR').upper(),
+            producer_name=record.supplier_id.name or 'Unknown Producer',
+            country_of_activity=base_vals['country_of_activity'],
+            border_cross_country=base_vals['border_cross_country'],
+            geojson_b64=geojson_b64,
+            comment=comment_text,
+        )
 
     envelope = client.build_envelope(submit_xml)
 

--- a/planetio/views/eudr_views.xml
+++ b/planetio/views/eudr_views.xml
@@ -39,7 +39,7 @@
     <field name="arch" type="xml">
       <form string="EUDR Declaration">
         <header>
-          <button name="action_open_import_wizard" type="object" string="Carica documenti" help="Importa Excel o Json con informazioni di geolocalizzazione oppure pdf o doc con informazioni aggiuntive." class="btn-secondary" icon="fa-upload"/>
+          <button name="action_open_import_wizard" type="object" string="Carica documenti" help="Importa Excel o Json con informazioni di geolocalizzazione oppure pdf o doc con informazioni aggiuntive." class="btn-secondary" icon="fa-upload" attrs="{'invisible': [('dds_mode','=','trader_refs')]}"/>
           <button name="action_analyze_deforestation" type="object" class="oe_highlight btn-success" string="Deforestation analysis" icon="fa-tree"/>
           <button name="action_create_deforestation_geojson" type="object" class="btn-secondary" string="Deforestation GeoJSON" icon="fa-download" invisible="1"/>
           <button name="action_create_geojson" type="object" class="btn-secondary" string="Traces GeoJSON" icon="fa-save" invisible="1"/>
@@ -62,6 +62,7 @@
           <group>
             <field name="company_id"/>
             <field name="datestamp" string="Creation date"/>
+            <field name="dds_mode"/>
 <!--            &lt;!&ndash; eudr_type_override solo per Mixed &ndash;&gt;-->
 <!--            <field name="eudr_type_override"-->
 <!--                  attrs="{'invisible': [('eudr_company_type_rel','!=','mixed')]}"/>-->
@@ -146,7 +147,7 @@
           </group>
 
           <notebook>
-            <page string="Details">
+            <page string="Details" attrs="{'invisible': [('dds_mode','!=','single_one')]}">
               <field name="line_ids">
                 <tree string="Dettagli" decoration-success="external_ok" decoration-danger="not external_ok" editable="top">
                   <field name="external_ok" widget="boolean_toggle" readonly="0" string=""/>
@@ -237,10 +238,97 @@
                           <group>
                             <field name="payload_json" widget="text" readonly="1"/>
                           </group>
-                        </form>
-                      </field>
-                    </page>
-                  </notebook>
+                </form>
+              </field>
+            </page>
+            <page string="Commodities" attrs="{'invisible': [('dds_mode','=','trader_refs')]}" name="multi_commodities_page">
+              <group attrs="{'invisible': [('dds_mode','=','single_multi')]}" class="mb-2">
+                <label string="Switch to Multiple commodities to edit this tab."/>
+              </group>
+              <field name="commodity_ids" attrs="{'readonly': [('dds_mode','!=','single_multi')]}">
+                <tree editable="bottom">
+                  <field name="hs_heading"/>
+                  <field name="description_of_goods"/>
+                  <field name="net_weight_kg"/>
+                  <field name="producer_ids" widget="one2many_list" optional="hide"/>
+                </tree>
+                <form string="Commodity">
+                  <sheet>
+                    <group>
+                      <group>
+                        <field name="hs_heading"/>
+                        <field name="description_of_goods"/>
+                      </group>
+                      <group>
+                        <field name="net_weight_kg"/>
+                      </group>
+                    </group>
+                    <notebook>
+                      <page string="Producers">
+                        <field name="producer_ids">
+                          <tree editable="bottom">
+                            <field name="name"/>
+                            <field name="country"/>
+                          </tree>
+                          <form string="Producer">
+                            <sheet>
+                              <group>
+                                <field name="name"/>
+                                <field name="country"/>
+                              </group>
+                              <group string="Plots">
+                                <field name="plot_ids">
+                                  <tree editable="bottom">
+                                    <field name="plot_id"/>
+                                    <field name="country_of_production"/>
+                                    <field name="area_ha"/>
+                                  </tree>
+                                  <form string="Plot">
+                                    <sheet>
+                                      <group>
+                                        <field name="plot_id"/>
+                                        <field name="country_of_production"/>
+                                        <field name="area_ha"/>
+                                      </group>
+                                      <group>
+                                        <field name="geometry" widget="text"/>
+                                      </group>
+                                      <footer>
+                                        <button name="action_open_geojson" type="object" string="Preview on geojson.io" class="btn-secondary"/>
+                                        <button string="Close" class="btn-secondary" special="cancel"/>
+                                      </footer>
+                                    </sheet>
+                                  </form>
+                                </field>
+                              </group>
+                            </sheet>
+                          </form>
+                        </field>
+                      </page>
+                    </notebook>
+                  </sheet>
+                </form>
+              </field>
+            </page>
+            <page string="Associated Statements" attrs="{'invisible': [('dds_mode','!=','trader_refs')]}">
+              <field name="associated_statement_ids">
+                <tree editable="bottom">
+                  <field name="upstream_reference_number"/>
+                  <field name="upstream_dds_identifier"/>
+                  <field name="note"/>
+                </tree>
+                <form string="Associated Statement">
+                  <sheet>
+                    <group>
+                      <field name="upstream_reference_number"/>
+                      <field name="upstream_dds_identifier"/>
+                      <field name="note"/>
+                    </group>
+                  </sheet>
+                </form>
+              </field>
+            </page>
+          </notebook>
                 </form>
               </field>
           </page>

--- a/planetio/wizards/import_wizard.xml
+++ b/planetio/wizards/import_wizard.xml
@@ -24,10 +24,17 @@
             <!-- STEP: UPLOAD -->
             <field name="step" invisible="1"/>
             <field name="debug_import" invisible="1"/>
+            <field name="declaration_id" invisible="1"/>
             <group attrs="{'invisible':[('step','!=','upload')]}" >
               <field name="template_id" required="1" invisible="1"/>
               <field name="file_name" readonly="1"/>
               <field name="file_data" filename="file_name"/>
+            </group>
+            <group attrs="{'invisible':[('declaration_id.dds_mode','!=','single_multi')]}" string="Multi-commodity options">
+              <field name="import_mode"/>
+              <field name="target_commodity_id" attrs="{'required': [('import_mode','=','attach')]}">
+              </field>
+              <field name="single_producer"/>
             </group>
 
             <!-- STEP: MAP -->


### PR DESCRIPTION
## Summary
- add declaration submission modes with dedicated commodity, producer, plot, and associated statement records
- extend the EUDR adapter to emit multi-commodity and trader reference XML payloads while keeping the legacy single flow
- update the declaration UI and import wizard to manage commodities, producers, plots, and associated statements

## Testing
- python3 -m compileall planetio

------
https://chatgpt.com/codex/tasks/task_e_68e4ee8473b0833380648f44d5280ae3

## Summary by Sourcery

Support multi-commodity and trader reference modes in EUDR declarations by adding new data models, extending import flows, updating views, and enhancing XML payload generation while preserving the legacy single-commodity submission.

New Features:
- Add multi-commodity and trader reference submission modes alongside the legacy single-commodity flow
- Introduce models for commodities, producers, plots, and associated statements to capture multi-commodity data
- Extend the import wizard and Excel import to create or attach multi-commodity records with optional single-producer grouping
- Enhance EUDR adapter to generate XML payloads for multi-commodity and trader reference submissions
- Update declaration views to show detail, commodities, and associated statements tabs based on the selected submission mode

Enhancements:
- Compute total declaration area by combining line geometries and commodity plot areas